### PR TITLE
fix: update glob API usage for v11+ compatibility

### DIFF
--- a/packages/vscode-extension/tests/suite/index.ts
+++ b/packages/vscode-extension/tests/suite/index.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as Mocha from "mocha";
-import * as glob from "glob";
+import { glob } from "glob";
 
 export async function run(): Promise<void> {
   // Create the mocha test
@@ -11,7 +11,7 @@ export async function run(): Promise<void> {
 
   const testsRoot = __dirname;
 
-  const files = await glob.glob("**/**.test.js", { cwd: testsRoot });
+  const files = await glob("**/**.test.js", { cwd: testsRoot });
 
   // Add files to the test suite
   files.forEach((f: string) => mocha.addFile(path.resolve(testsRoot, f)));


### PR DESCRIPTION
Fixes #30

## Summary

Update glob import and function call to use the new v11+ API.

## Changes

- Changed from 'import * as glob' to 'import { glob }' (named export)
- Changed from 'glob.glob()' to 'glob()' (direct call)

## Testing

Verified webpack build completes without TypeScript errors.