### PR TITLE
fix: Electron-appでFILESペインのファイルが開けない不具合を修正

### DIFF
--- a/packages/electron-app/src/renderer/app.scss
+++ b/packages/electron-app/src/renderer/app.scss
@@ -167,7 +167,10 @@ main {
   border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
-  flex-shrink: 0; /* Important for resizing */
+  flex-shrink: 0;
+  z-index: 10;
+  position: relative;
+  pointer-events: auto;
 }
 
 .sidebar-title {
@@ -201,6 +204,10 @@ main {
     background-color: var(--hover-bg);
     color: var(--accent-color);
   }
+
+  /* Ensure items are clickable by sitting above resizer borders if they overlap */
+  position: relative;
+  z-index: 20;
 }
 
 #content {
@@ -643,10 +650,12 @@ table {
 .resizer-v {
   width: 4px;
   cursor: ew-resize;
-  margin-left: -2px; /* Center over border? Or just take space? */
-  background-color: var(--border-color); /* Temporary visual aid */
+  margin-left: -2px; /* Center over border */
+  background-color: var(--border-color);
   opacity: 0.5;
-  height: 100%; /* Force height */
+  z-index: 15; /* Higher than sidebar base (10) but lower than items (20) */
+  pointer-events: auto;
+  height: 100%;
   display: block;
 }
 

--- a/packages/electron-app/src/renderer/renderer.ts
+++ b/packages/electron-app/src/renderer/renderer.ts
@@ -174,8 +174,9 @@ class AppController {
     this.threadList.onCommentClick = (tid, cid) => this.syncSelection(tid, cid);
 
     // Recent Files Events
-    this.recentFilesView.onFileClick = (path) =>
+    this.recentFilesView.onFileClick = (path) => {
       this.ipc.openFileSpecific(path);
+    };
 
     // Dialog Events
     this.addCommentDialog.onSave = async (content) =>
@@ -340,6 +341,7 @@ class AppController {
   }
 
   private setCurrentFile(path: string) {
+    console.log("AppController: setCurrentFile", path);
     this.currentFilePath = path;
     this.toolbar.updateFileName(path);
   }

--- a/packages/electron-app/src/renderer/views/RecentFilesView.ts
+++ b/packages/electron-app/src/renderer/views/RecentFilesView.ts
@@ -9,14 +9,22 @@ export class RecentFilesView extends Component {
 
   public render(files: string[]): void {
     this.element.innerHTML = "";
-    files.forEach((file) => {
+    // Remove duplicates to prevent ID collisions and redundant entries
+    const uniqueFiles = [...new Set(files)];
+
+    uniqueFiles.forEach((file, index) => {
       const item = document.createElement("div");
       item.className = "recent-file-item";
+      item.id = `recent-file-${index}`;
       item.innerText = file.split(/[\\/]/).pop() || "";
       item.title = file;
-      item.onclick = () => {
-        if (this.onFileClick) this.onFileClick(file);
-      };
+
+      item.addEventListener("click", () => {
+        if (this.onFileClick) {
+          this.onFileClick(file);
+        }
+      });
+
       this.element.appendChild(item);
     });
   }


### PR DESCRIPTION
## 概要
Electron-appのサイドバー「FILES」ペインでファイルをクリックしても反応しない不具合を修正しました。

## 修正内容
- **UI重なり問題の解消**: \z-index\ を調整し、ファイルリストアイテムがリサイザーより前面に来るように修正。
- **イベントハンドラの堅牢化**: \onclick\ から \ddEventListener\ に変更。
- **重複表示の抑制**: サイドバーに同じファイルが複数表示されないよう修正。

## 検証結果
Playwright を使用した E2E テストで、サイドバーのファイルクリックによりプレビューが正常に更新されることを確認しました。

Closes #33