### PR TITLE
feat(#37): Implement overlapping comment logic

### DIFF
--- a/packages/core/src/application/ShowPreviewUseCase.ts
+++ b/packages/core/src/application/ShowPreviewUseCase.ts
@@ -55,7 +55,11 @@ export class ShowPreviewUseCase {
     const { htmlContent: htmlContentWithPlaceholders } =
       this.annotationService.injectPlaceholders(
         document.content,
-        threads as any[],
+        threads.map((t) => ({
+          id: t.id,
+          anchor: t.anchor,
+          createdAt: t.comments[0]?.createdAt,
+        })),
       );
 
     const title = `Preview ${document.filePath.split(/[\\/]/).pop()}`;


### PR DESCRIPTION
Closes #37.

## Goal Description
Implement logic to control the display order of overlapping comment highlights in the Preview view.
- **Range Start Position**: Ranges starting later should be displayed in front (inner).
- **Same Start Position**: Later created comments should be displayed in front.

## Changes
- Updated \AnnotationService.ts\ to sort active threads by Start Offset (DESC) and CreatedAt (DESC).
- Updated \ShowPreviewUseCase.ts\ to pass \createdAt\ timestamp.
- Added unit tests in \AnnotationService.test.ts\ for nested and identical ranges.

## Verification
- Verified with unit tests covering nested and identical range scenarios.